### PR TITLE
Prevent length extension attack on network seed

### DIFF
--- a/proposals/posts/~2018.11.8..19.31.59..ba77~.md
+++ b/proposals/posts/~2018.11.8..19.31.59..ba77~.md
@@ -125,7 +125,8 @@ Optional string, used when turning generated BIP39 mnemonics into BIP32 seeds.
       <li>Convert the "management" seed (mnemonic phrase) plus the optional passphrase into a BIP32 seed, as specified in BIP39</li>
       <li>Append the revision number to the string "network" (ie "network0"); the revision number defaults to 0</li>
       <li>Append that whole string to the BIP32 seed</li>
-      <li>Hash the "salted" BIP32 seed using SHA2-256</li>
+      <li>For a revision number of `0`, hash the "salted" BIP32 seed using SHA2-256</li>
+      <li>For higher revision numbers, hash the "salted" BIP32 seed using SHA2-256d (hash with SHA2-256 twice)</li>
     </ul>
   </li>
   <li>Optionally, for the type "network", derive encryption and authentication keys as follows (identical to `++pit:nu:crub:crypto` in Urbit's standard library, <a href="https://github.com/urbit/arvo/blob/master/sys/zuse.hoon">zuse</a>):


### PR DESCRIPTION
As described in urbit/keygen-js#55, the use of SHA2-256 in networking seed derivation is vulnerable to length-extension attacks. This change patches that vulnerability.

Since network seeds have already been generated with revision 0, that case needs to remain backwards-compatible, and thus will not change. All other cases will change, doing SHA2-256d (hashing twice with SHA2-256) to protect against length extension attacks.

Note that network seeds generated with revision 0 are not vulnerable to length extension attacks themselves, because the revision number as part of the salt should never have unnecessary leading zeroes.